### PR TITLE
List reply system + Showing emoji numbers in lists

### DIFF
--- a/nap/lib/bot/KBase.js
+++ b/nap/lib/bot/KBase.js
@@ -133,11 +133,21 @@ KBase = {
         }
         // else
         Utils.log("shortList", shortList);
+
+        var emojiList = [':zero:', ':one:', ':two:', ':three:', ':four:', 
+                            ':five:', ':six:', ':seven:', ':eight:', ':nine:'];
+
         var findResults = "";
         for (var i = 0; i < shortList.length; i++) {
             var topicData = shortList[i];
             var link = Utils.linkify(topicData.dashedName, 'wiki', topicData.displayName);
-            var line = "\n[" + i + "] " + link;
+            if (i < 10) {
+                var line = "\n " + emojiList[i] + " " + link;
+            } else if (i < 100) {
+                var iSplit = i.toString().split('');
+                var line = "\n " + emojiList[iSplit[0]] +
+                            emojiList[iSplit[1]] + " " + link;
+            }
             findResults += line;
         }
         return findResults;


### PR DESCRIPTION
currently it has some regex matching to get list items out of bot reply links
under `makeListOptions` method in `GBot.js`

and sends `{ params: <list-item> }` as an input to `wiki` method in `BotCommands.js`

fix for issue #36