### PR TITLE
better path seperator

### DIFF
--- a/nap/lib/bot/KBase.js
+++ b/nap/lib/bot/KBase.js
@@ -57,10 +57,7 @@ KBase = {
                 //console.log("skipping " + name);
             } else {
                 var filePath = path.join(wikiDataDir, name);
-                var arr = filePath.split("/");
-                if (arr.length === 1) {
-                    arr = filePath.split("\\");
-                }
+                var arr = filePath.split(path.sep);
                 var fileName = arr[arr.length - 1];
                 fileName = fileName.toLowerCase();
                 var topicName = fileName.replace(".md", "");


### PR DESCRIPTION
looks like `path.sep` changes to `\\` or `/` based on platform.

https://nodejs.org/api/path.html#path_path_sep

paths should be x-platform from now on :)