### PR TITLE
replaced plug.dj link for music command with 8tracks 

### DIFF
--- a/nap/lib/bot/BotCommands.js
+++ b/nap/lib/bot/BotCommands.js
@@ -255,7 +255,7 @@ var BotCommands = {
     // },
     music: function (input, bot) {
         var str = "## Music!";
-        str += "\n http://plug.dj/freecodecamp";
+        str += "\n http://8tracks.com/quincylarson/quincy-larson-s-flow-state-coding-playlist";
         return str;
     },
 


### PR DESCRIPTION
Replace defunct link to plug.dj in `music` command with a link to Quincy's coding playlist on 8tracks

close #180

I realize there is already a PR to close this issue ( #181 ) but that just comments out the command. It's up to you if the command should spit a different music link or if you want to have it commented out. 

cc: @dcsan 