### PR TITLE
updated apiServer to fix 301 redirect error

### DIFF
--- a/nap/config/AppConfig.js
+++ b/nap/config/AppConfig.js
@@ -115,21 +115,21 @@ var envConfigs = {
     demobot: {
         botname: "demobot",
         appHost: "http://localhost:7000",
-        apiServer: "freecodecamp.com",
+        apiServer: "www.freecodecamp.com",
         appRedirectUrl: "http://localhost:7891/login/callback",
     },
 
     test: {
         botname: "bothelp",
         appHost: "http://localhost:7000",
-        apiServer: "freecodecamp.com",
+        apiServer: "www.freecodecamp.com",
         appRedirectUrl: "http://localhost:7891/login/callback",
     },
 
     local: {
         botname: "bothelp",
         appHost: "http://localhost:7000",
-        apiServer: "freecodecamp.com",
+        apiServer: "www.freecodecamp.com",
         appRedirectUrl: "http://localhost:7891/login/callback",
     },
     beta: {
@@ -141,7 +141,7 @@ var envConfigs = {
     prod: {
         botname: "camperbot",
         appHost: "http://bot.freecodecamp.com",
-        apiServer: "freecodecamp.com",
+        apiServer: "www.freecodecamp.com",
         appRedirectUrl: "http://bot.freecodecamp.com/login/callback",
     }
 };


### PR DESCRIPTION
The api was reporting offline because after the FCC DNS update calls to freecodecamp.com are being redirected to www.freecodecamp.com.

I've updated nap/config/AppConfig.js to use the correct path for the apiServer. This fixed the issue with @purdybot already.

closes #188 
cc @dcsan & @abhisekp 